### PR TITLE
feat: Auth 서비스 유저 클래스 추가 및 이메일 체크, 회원가입 구현

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,1 @@
+# PhishingBlockServer Resources

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,1 @@
+# PhishingBlockServer Scripts

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  phishing-mysql:
+    image: mysql:latest
+    container_name: phishing-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: phishing
+      MYSQL_USER: phishing
+      MYSQL_PASSWORD: phishing
+      TZ: Asia/Seoul
+    command: [ "--character-set-server=utf8mb4" ]
+    ports:
+      - "3306:3306"
+    networks:
+      - phishing-network
+  phishing-adminer:
+    image: adminer:latest
+    container_name: phishing-adminer
+    environment:
+      ADMINER_DEFAULT_SERVER: phishing-mysql
+    ports:
+      - "18080:8080"
+    networks:
+      - phishing-network
+  phishing-redis:
+    image: redis:latest
+    container_name: phishing-redis
+    ports:
+      - "6379:6379"
+    networks:
+      - phishing-network
+networks:
+    phishing-network:
+        driver: bridge

--- a/scripts/env-start.sh
+++ b/scripts/env-start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker-compose down
+docker-compose up -d

--- a/src/auth-service/build.gradle
+++ b/src/auth-service/build.gradle
@@ -23,9 +23,17 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 tasks.named('test') {

--- a/src/auth-service/build.gradle
+++ b/src/auth-service/build.gradle
@@ -22,17 +22,27 @@ repositories {
 }
 
 dependencies {
+	// Spring Boot MVC
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	//Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Spring Data JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// DB Connection
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// Security
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 }
 

--- a/src/auth-service/src/main/java/com/phishing/authservice/config/RedisConfig.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/config/RedisConfig.java
@@ -10,10 +10,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int port;
 
     @Bean

--- a/src/auth-service/src/main/java/com/phishing/authservice/config/RedisConfig.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.phishing.authservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.phishing.authservice.controller;
+
+import com.phishing.authservice.dto.request.SignUpRequest;
+import com.phishing.authservice.service.AuthService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Validated
+public class AuthController {
+    private final AuthService authService;
+
+    @GetMapping("/users/check")
+    public ResponseEntity<?> checkEmail(@RequestParam @Valid @NotNull String email) {
+        authService.checkEmail(email);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signUp(@RequestBody @Valid SignUpRequest request) {
+        authService.signUp(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
@@ -1,0 +1,30 @@
+package com.phishing.authservice.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "email", nullable = false, length = 50)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 20)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, length = 15)
+    private String nickname;
+
+    @Column(name = "phnum", nullable = false, length = 20)
+    private String phnum;
+
+    @Column(name = "role", nullable = false, length = 10)
+    private UserRole role;
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
@@ -27,4 +27,13 @@ public class User {
 
     @Column(name = "role", nullable = false, length = 10)
     private UserRole role;
+
+    @Builder
+    public User(String email, String password, String nickname, String phnum, UserRole role) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.phnum = phnum;
+        this.role = role;
+    }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/domain/UserRole.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/domain/UserRole.java
@@ -1,0 +1,15 @@
+package com.phishing.authservice.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private String type;
+
+    UserRole(String type) {
+        this.type = type;
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/dto/request/SignUpRequest.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/dto/request/SignUpRequest.java
@@ -1,0 +1,9 @@
+package com.phishing.authservice.dto.request;
+
+public record SignUpRequest(
+        String email,
+        String password,
+        String nickname,
+        String phnum
+) {
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/exception/GlobalExceptionHandler.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.phishing.authservice.exception;
+
+import com.phishing.authservice.exception.exceptions.DuplicateEmailException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DuplicateEmailException.class)
+    protected ResponseEntity<?> handleDuplicateEmailException(DuplicateEmailException e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/exception/exceptions/DuplicateEmailException.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/exception/exceptions/DuplicateEmailException.java
@@ -1,0 +1,7 @@
+package com.phishing.authservice.exception.exceptions;
+
+public class DuplicateEmailException extends RuntimeException{
+    public DuplicateEmailException(String email) {
+        super("Email already exists: " + email);
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/repository/UserRepository.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.phishing.authservice.repository;
+
+import com.phishing.authservice.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
@@ -1,0 +1,42 @@
+package com.phishing.authservice.service;
+
+import com.phishing.authservice.domain.User;
+import com.phishing.authservice.domain.UserRole;
+import com.phishing.authservice.dto.request.SignUpRequest;
+import com.phishing.authservice.exception.exceptions.DuplicateEmailException;
+import com.phishing.authservice.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+
+    private final UserRepository userRepository;
+
+    public void checkEmail(String email) {
+        // Check if email already exists
+        if (userRepository.existsByEmail(email)) {
+            throw new DuplicateEmailException("Email already exists");
+        }
+    }
+
+    public void signUp(SignUpRequest request) {
+        // Check if email already exists
+        checkEmail(request.email());
+        // Save user
+        userRepository.save(User.builder()
+                        .email(request.email())
+                        .password(request.password())
+                        .nickname(request.nickname())
+                        .phnum(request.phnum())
+                        .role(UserRole.USER)
+                .build());
+    }
+
+
+}

--- a/src/auth-service/src/main/resources/application.yml
+++ b/src/auth-service/src/main/resources/application.yml
@@ -3,3 +3,15 @@ spring:
     redis:
         host: localhost
         port: 6379
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: phishing
+    password: phishing
+    url: jdbc:mysql://localhost:3306/phishing?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    hibernate:
+      ddl-auto: create-drop

--- a/src/auth-service/src/main/resources/application.yml
+++ b/src/auth-service/src/main/resources/application.yml
@@ -1,1 +1,5 @@
-
+spring:
+  data:
+    redis:
+        host: localhost
+        port: 6379


### PR DESCRIPTION
### Issue Number or Link
#8 

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
Auth 서비스 유저 클래스 추가 및 이메일 체크, 회원가입 구현

### 상세 내용(Describe your changes)
Auth 서비스의 유저 클래스를 추가하였습니다.
![스크린샷 2024-02-29 오후 7 23 20](https://github.com/CBNU-Senior-Project/PhishingBlockServer/assets/58455389/f925be2a-5ae5-4f34-8aeb-5133f4a84cdc)
User 테이블은 다음과 같이 이루어져 있고, 변경사항 발생시 이슈에 남기겠습니다.

이메일 체크는 로그인 시 이메일을 통한 로그인을 구현 할 예정이기 때문에 이메일이 유니크 할 필요가 있으므로 검증합니다.
추후 해당 컨트롤러 메소드에서 반환 값을 수정할 계획입니다.

회원가입은
- email
- password
- nickname
- phnum

이렇게 4가지를 전달 받습니다.
이후 다시한번 이메일을 검증 한 후 회원가입을 진행합니다.