### PR TITLE
feat: Auth 서비스 회원가입 로직 변경 및 로그인 구현

### DIFF
--- a/src/auth-service/build.gradle
+++ b/src/auth-service/build.gradle
@@ -23,7 +23,6 @@ repositories {
 
 dependencies {
 	// Spring Boot MVC
-	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
@@ -42,7 +41,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	// Security
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 }
 

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/ReturnToken.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/ReturnToken.java
@@ -1,0 +1,7 @@
+package com.phishing.authservice.component.token;
+
+public record ReturnToken (
+        String accessToken,
+        String refreshToken
+){
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
@@ -1,0 +1,54 @@
+package com.phishing.authservice.component.token;
+
+import com.phishing.authservice.domain.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class TokenProvider {
+
+    @Value("${jwt.secret.access}")
+    private long ACCESS_TIME;
+
+    @Value("${jwt.secret.refresh}")
+    private long REFRESH_TIME;
+
+    @Value("${jwt.secret.key}")
+    private String SECRET_KEY;
+
+    public ReturnToken provideTokens(User user) {
+        Claims claims = buildClaims(user);
+        Claims refresh_claims = buildClaims(user.getId());
+        return new ReturnToken(
+                generateToken(claims, ACCESS_TIME),
+                generateToken(refresh_claims, REFRESH_TIME)
+        );
+    }
+    private String generateToken(Claims claims, long time) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(new Date(System.currentTimeMillis() + time))
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+    }
+
+    private static Claims buildClaims(User user) {
+        Claims claims = Jwts.claims();
+        claims.put("USER_ID", user.getId());
+        claims.put("USER_NICKNAME", user.getNickname());
+        claims.put("USER_ROLE", user.getRole());
+        return claims;
+    }
+
+    private static Claims buildClaims(Long id) {
+        Claims claims = Jwts.claims();
+        claims.put("USER_ID", id);
+        return claims;
+    }
+
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/config/EncoderConfig.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/config/EncoderConfig.java
@@ -1,0 +1,18 @@
+package com.phishing.authservice.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class EncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/config/SecurityConfig.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.phishing.authservice.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/v1/**").permitAll()
+                        .requestMatchers("/api/v1/signout").authenticated()
+                )
+                .build();
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.phishing.authservice.controller;
 
+import com.phishing.authservice.dto.request.SignInRequest;
 import com.phishing.authservice.dto.request.SignUpRequest;
 import com.phishing.authservice.service.AuthService;
 import jakarta.validation.Valid;
@@ -26,5 +27,10 @@ public class AuthController {
     public ResponseEntity<?> signUp(@RequestBody @Valid SignUpRequest request) {
         authService.signUp(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequest request) {
+        return ResponseEntity.ok(authService.signIn(request));
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
@@ -2,9 +2,12 @@ package com.phishing.authservice.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 @Entity
 public class User {
 
@@ -16,7 +19,7 @@ public class User {
     @Column(name = "email", nullable = false, length = 50)
     private String email;
 
-    @Column(name = "password", nullable = false, length = 20)
+    @Column(name = "password", nullable = false, length = 100)
     private String password;
 
     @Column(name = "nickname", nullable = false, length = 15)
@@ -28,12 +31,23 @@ public class User {
     @Column(name = "role", nullable = false, length = 10)
     private UserRole role;
 
-    @Builder
-    public User(String email, String password, String nickname, String phnum, UserRole role) {
-        this.email = email;
-        this.password = password;
-        this.nickname = nickname;
-        this.phnum = phnum;
-        this.role = role;
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public static User signUp(String email, String password, String nickname, String phnum) {
+        return User.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .phnum(phnum)
+                .role(UserRole.USER)
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/domain/UserRole.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/domain/UserRole.java
@@ -1,15 +1,6 @@
 package com.phishing.authservice.domain;
 
-import lombok.Getter;
-
-@Getter
 public enum UserRole {
-    USER("ROLE_USER"),
-    ADMIN("ROLE_ADMIN");
-
-    private String type;
-
-    UserRole(String type) {
-        this.type = type;
-    }
+    USER,
+    ADMIN
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/dto/request/SignInRequest.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/dto/request/SignInRequest.java
@@ -1,0 +1,7 @@
+package com.phishing.authservice.dto.request;
+
+public record SignInRequest(
+    String email,
+    String password
+) {
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/exception/exceptions/InvalidPasswordException.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/exception/exceptions/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.phishing.authservice.exception.exceptions;
+
+public class InvalidPasswordException extends RuntimeException{
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/redis/RedisDao.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/redis/RedisDao.java
@@ -1,0 +1,33 @@
+package com.phishing.authservice.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisDao {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setRedisValues (String key, String value, Duration time) {
+        if (getRedisValues(key) != null){
+            deleteRedisValues(key);
+        }
+        redisTemplate.opsForValue().set(key, value, time);
+    }
+
+    public String getRedisValues (String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteRedisValues (String key) {
+        redisTemplate.delete(key);
+    }
+
+    public boolean isExistKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/repository/UserRepository.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/repository/UserRepository.java
@@ -3,6 +3,9 @@ package com.phishing.authservice.repository;
 import com.phishing.authservice.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
@@ -1,14 +1,23 @@
 package com.phishing.authservice.service;
 
+import com.phishing.authservice.component.token.ReturnToken;
+import com.phishing.authservice.component.token.TokenProvider;
 import com.phishing.authservice.domain.User;
 import com.phishing.authservice.domain.UserRole;
+import com.phishing.authservice.dto.request.SignInRequest;
 import com.phishing.authservice.dto.request.SignUpRequest;
 import com.phishing.authservice.exception.exceptions.DuplicateEmailException;
+import com.phishing.authservice.exception.exceptions.InvalidPasswordException;
+import com.phishing.authservice.redis.RedisDao;
 import com.phishing.authservice.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
 
 @Service
 @Transactional
@@ -17,7 +26,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final RedisDao redisDao;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
 
+    @Value("${jwt.secret.refresh}")
+    private Long refreshTime;
+
+    @Transactional
     public void checkEmail(String email) {
         // Check if email already exists
         if (userRepository.existsByEmail(email)) {
@@ -25,18 +41,36 @@ public class AuthService {
         }
     }
 
+    @Transactional
     public void signUp(SignUpRequest request) {
         // Check if email already exists
         checkEmail(request.email());
+        // Create user
+        User user = User.signUp(
+                request.email(),
+                passwordEncoder.encode(request.password()),
+                request.nickname(),
+                request.phnum()
+        );
         // Save user
-        userRepository.save(User.builder()
-                        .email(request.email())
-                        .password(request.password())
-                        .nickname(request.nickname())
-                        .phnum(request.phnum())
-                        .role(UserRole.USER)
-                .build());
+        userRepository.save(user);
     }
 
+    @Transactional
+    public ReturnToken signIn(SignInRequest request) {
+        // Check if email isn't exists
+        userRepository.existsByEmail(request.email());
+        // Check if password is correct
+        User loginUser = userRepository.findByEmail(request.email())
+                .filter(user -> passwordEncoder.matches(request.password(), user.getPassword()))
+                .orElseThrow(() -> new InvalidPasswordException("Invalid password"));
+        // return jwt token
+        ReturnToken returnToken = tokenProvider.provideTokens(loginUser);
+        // save refresh token in redis
+        redisDao.setRedisValues(String.valueOf(loginUser.getId()),
+                returnToken.refreshToken(), Duration.ofMillis(refreshTime));
+
+        return returnToken;
+    }
 
 }

--- a/src/auth-service/src/main/resources/application-jwt.yml
+++ b/src/auth-service/src/main/resources/application-jwt.yml
@@ -1,0 +1,5 @@
+jwt:
+  secret:
+    access: 86400000
+    refresh: 86400000
+    key: secretKeysecretKeysecretKeysecretKeysecretKeysecretKeysecretKeysecretKeysecretKey

--- a/src/auth-service/src/main/resources/application.yml
+++ b/src/auth-service/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: jwt
   data:
     redis:
         host: localhost


### PR DESCRIPTION
### Issue Number or Link
#12  

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
Auth 서비스 회원가입 로직 변경 및 로그인 구현

### 상세 내용(Describe your changes)
**Auth 서비스의 회원가입 로직을 변경하였습니다.**
- 기존 비밀번호를 그대로 DB에 저장하는 로직에서, Spring Security에서 지원하는 BCryptPasswordEncoder를 통해 암호화하여 저장합니다.

**Auth 서비스의 로그인 기능을 구현하였습니다.**
- 로그인 시 입력된 email과 password를 비교하여 인증을 시도합니다.
- 인증이 완료 된 경우, Access Token과 Refresh Token을 클라이언트에 반환합니다.
- 서버에서는 Refresh Token을 Redis DB에 저장하여 보관합니다.

