### PR TITLE
feat: Auth 서비스 로그아웃 기능 구현

### DIFF
--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
@@ -23,7 +23,7 @@ public class TokenProvider {
 
     public ReturnToken provideTokens(User user) {
         Claims claims = buildClaims(user);
-        Claims refresh_claims = buildClaims(user.getId());
+        Claims refresh_claims = buildClaims(user.getEmail());
         return new ReturnToken(
                 generateToken(claims, ACCESS_TIME),
                 generateToken(refresh_claims, REFRESH_TIME)
@@ -39,15 +39,15 @@ public class TokenProvider {
 
     private static Claims buildClaims(User user) {
         Claims claims = Jwts.claims();
-        claims.put("USER_ID", user.getId());
+        claims.put("USER_ID", user.getEmail());
         claims.put("USER_NICKNAME", user.getNickname());
         claims.put("USER_ROLE", user.getRole());
         return claims;
     }
 
-    private static Claims buildClaims(Long id) {
+    private static Claims buildClaims(String email) {
         Claims claims = Jwts.claims();
-        claims.put("USER_ID", id);
+        claims.put("USER_ID", email);
         return claims;
     }
 

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenResolver.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenResolver.java
@@ -1,0 +1,45 @@
+package com.phishing.authservice.component.token;
+
+import com.phishing.authservice.domain.UserRole;
+import com.phishing.authservice.payload.MemberInfo;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenResolver {
+
+    @Value("${jwt.secret.key}")
+    private String SECRET_KEY;
+
+    public MemberInfo getClaims(String token){
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(SECRET_KEY)
+                .build()
+                .parseClaimsJws(removePrefix(token))
+                .getBody();
+
+        return MemberInfo.builder()
+                .email(claims.get("USER_ID", String.class))
+                .nickname(claims.get("USER_NICKNAME", String.class))
+                .role(UserRole.valueOf(claims.get("USER_ROLE", String.class)))
+                .build();
+    }
+
+    public long getExpiration(String token){
+        return Jwts.parserBuilder()
+                .setSigningKey(SECRET_KEY)
+                .build()
+                .parseClaimsJws(removePrefix(token))
+                .getBody()
+                .getExpiration()
+                .getTime();
+    }
+
+    private String removePrefix(String token){
+        return token.replace("Bearer ", "");
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.phishing.authservice.dto.request.SignUpRequest;
 import com.phishing.authservice.dto.request.VerifyEmailRequest;
 import com.phishing.authservice.service.AuthService;
 import com.phishing.authservice.service.MailService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -47,5 +48,11 @@ public class AuthController {
     @PostMapping("/signin")
     public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequest request) {
         return ResponseEntity.ok(authService.signIn(request));
+    }
+
+    @PostMapping("/signout")
+    public ResponseEntity<?> signOut(HttpServletRequest request){
+        authService.signOut(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/payload/MemberInfo.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/payload/MemberInfo.java
@@ -1,0 +1,12 @@
+package com.phishing.authservice.payload;
+
+import com.phishing.authservice.domain.UserRole;
+import lombok.Builder;
+
+@Builder
+public record MemberInfo(
+        String email,
+        String nickname,
+        UserRole role
+) {
+}


### PR DESCRIPTION
### Issue Number or Link
#18 

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
Auth 서비스 로그아웃 기능 구현

### 상세 내용(Describe your changes)
**Auth 서비스의 로그아웃 기능을 구현하였습니다.**
로그아웃은 다음과 같은 시퀀스를 따라갑니다.
 1. 사용자에게 Access Token과 Refresh Token을 받습니다.
 2. Access Token을 통해 사용자의 email을 열람합니다.
 3. 해당 email을 통해 redis에 저장되어있는 refresh token을 삭제합니다.
 4. 사용자가 가지고 있는 refresh token을 남은 만료시간 까지 BlackList에 올립니다.

