### PR TITLE
feat: Auth 서비스 회원 정보 수정 및 기타 로직들 리팩토링

### DIFF
--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
@@ -1,13 +1,9 @@
 package com.phishing.authservice.controller;
 
 import com.phishing.authservice.dto.request.SignInRequest;
-import com.phishing.authservice.dto.request.SignUpRequest;
-import com.phishing.authservice.dto.request.VerifyEmailRequest;
 import com.phishing.authservice.service.AuthService;
-import com.phishing.authservice.service.MailService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -19,31 +15,6 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 public class AuthController {
     private final AuthService authService;
-    private final MailService mailService;
-
-    @GetMapping("/users/check")
-    public ResponseEntity<?> checkEmail(@RequestParam @Valid @NotNull String email) {
-        authService.checkEmail(email);
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/email/send")
-    public ResponseEntity<?> sendMail(@RequestParam @Valid @NotNull String email) {
-        mailService.sendMail(email);
-        return ResponseEntity.ok().build();
-    }
-
-    @PostMapping("/email/verify")
-    public ResponseEntity<?> verifyMail(@RequestBody @Valid VerifyEmailRequest request) {
-        mailService.verifyMail(request.email(), request.authCode());
-        return ResponseEntity.ok().build();
-    }
-
-    @PostMapping("/signup")
-    public ResponseEntity<?> signUp(@RequestBody @Valid SignUpRequest request) {
-        authService.signUp(request);
-        return ResponseEntity.ok().build();
-    }
 
     @PostMapping("/signin")
     public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequest request) {

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/UserController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/UserController.java
@@ -1,0 +1,54 @@
+package com.phishing.authservice.controller;
+
+import com.phishing.authservice.dto.request.EditProfileRequest;
+import com.phishing.authservice.dto.request.SignUpRequest;
+import com.phishing.authservice.dto.request.VerifyEmailRequest;
+import com.phishing.authservice.service.MailService;
+import com.phishing.authservice.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Validated
+public class UserController {
+    private final MailService mailService;
+    private final UserService userService;
+
+    @GetMapping("/users/check")
+    public ResponseEntity<?> checkEmail(@RequestParam @Valid @NotNull String email) {
+        userService.checkEmail(email);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/email/send")
+    public ResponseEntity<?> sendMail(@RequestParam @Valid @NotNull String email) {
+        mailService.sendMail(email);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<?> verifyMail(@RequestBody @Valid VerifyEmailRequest request) {
+        mailService.verifyMail(request.email(), request.authCode());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signUp(@RequestBody @Valid SignUpRequest request) {
+        userService.signUp(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/users/edit")
+    public ResponseEntity<?> editProfile(HttpServletRequest httpServletRequest
+            , @RequestBody @Valid EditProfileRequest editProfileRequest) {
+        userService.editProfile(httpServletRequest, editProfileRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
@@ -2,12 +2,15 @@ package com.phishing.authservice.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
+
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
+@DynamicUpdate
 @Entity
 public class User {
 
@@ -49,5 +52,11 @@ public class User {
                 .role(UserRole.USER)
                 .createdAt(LocalDateTime.now())
                 .build();
+    }
+
+    public void editProfile(String nickname, String phnum) {
+        this.nickname = nickname;
+        this.phnum = phnum;
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/dto/request/EditProfileRequest.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/dto/request/EditProfileRequest.java
@@ -1,0 +1,7 @@
+package com.phishing.authservice.dto.request;
+
+public record EditProfileRequest(
+        String nickname,
+        String phnum
+) {
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
@@ -36,27 +36,6 @@ public class AuthService {
     @Value("${jwt.secret.refresh}")
     private Long refreshTime;
 
-    public void checkEmail(String email) {
-        // Check if email already exists
-        if (userRepository.existsByEmail(email)) {
-            throw new DuplicateEmailException("Email already exists");
-        }
-    }
-
-    public void signUp(SignUpRequest request) {
-        // Check if email already exists
-        checkEmail(request.email());
-        // Create user
-        User user = User.signUp(
-                request.email(),
-                passwordEncoder.encode(request.password()),
-                request.nickname(),
-                request.phnum()
-        );
-        // Save user
-        userRepository.save(user);
-    }
-
     public ReturnToken signIn(SignInRequest request) {
         // Check if email isn't exists
         userRepository.existsByEmail(request.email());

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/UserService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/UserService.java
@@ -1,0 +1,65 @@
+package com.phishing.authservice.service;
+
+import com.phishing.authservice.component.token.TokenResolver;
+import com.phishing.authservice.domain.User;
+import com.phishing.authservice.dto.request.EditProfileRequest;
+import com.phishing.authservice.dto.request.SignUpRequest;
+import com.phishing.authservice.exception.exceptions.DuplicateEmailException;
+import com.phishing.authservice.payload.MemberInfo;
+import com.phishing.authservice.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenResolver tokenResolver;
+
+    public void checkEmail(String email) {
+        // Check if email already exists
+        if (userRepository.existsByEmail(email)) {
+            throw new DuplicateEmailException("Email already exists");
+        }
+    }
+
+    public void signUp(SignUpRequest request) {
+        // Check if email already exists
+        checkEmail(request.email());
+        // Create user
+        User user = User.signUp(
+                request.email(),
+                passwordEncoder.encode(request.password()),
+                request.nickname(),
+                request.phnum()
+        );
+        // Save user
+        userRepository.save(user);
+    }
+
+    public void editProfile(HttpServletRequest httpServletRequest, EditProfileRequest request){
+        MemberInfo memberInfo = getMemberInfoToToken(httpServletRequest);
+
+        User targetUser = userRepository.findByEmail(memberInfo.email())
+                .orElseThrow(() -> new DuplicateEmailException("Email Not exists"));
+
+        targetUser.editProfile(
+                request.nickname(),
+                request.phnum()
+        );
+        System.out.println("targetUser = " + targetUser.getNickname());
+    }
+
+    private MemberInfo getMemberInfoToToken(HttpServletRequest request) {
+        String token = request.getHeader("Authorization");
+        MemberInfo result = tokenResolver.getClaims(token);
+        return result;
+    }
+}


### PR DESCRIPTION
### Issue Number or Link
#20 

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
Auth 서비스 회원 정보 수정 및 기타 로직들 리팩토링

### 상세 내용(Describe your changes)
**Auth 서비스의 회원 정보 수정 기능을 구현하였습니다.**
- JPA의 영속성을 통한 Dirty checking으로 업데이트를 진행합니다.
- 회원 정보 수정은 닉네임과 전화번호만 가능합니다.

**기타 로직들을 리팩토링 하였습니다.**
- AuthService에 너무 많은 책임이 몰려 UserService와 AuthService로 분리하였습니다.
- 이에 따라 Controller 역시 UserController와 AuthController를 분리하였습니다.


