### PR TITLE
feat: Auth 서비스 회원 탈퇴 구현 및 기타 로직 리팩토링

### DIFF
--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
@@ -32,6 +32,7 @@ public class TokenProvider {
     private String generateToken(Claims claims, long time) {
         return Jwts.builder()
                 .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + time))
                 .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
                 .compact();

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenResolver.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenResolver.java
@@ -1,7 +1,7 @@
 package com.phishing.authservice.component.token;
 
 import com.phishing.authservice.domain.UserRole;
-import com.phishing.authservice.payload.MemberInfo;
+import com.phishing.authservice.payload.token.MemberInfo;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.phishing.authservice.controller;
 
-import com.phishing.authservice.dto.request.SignInRequest;
+import com.phishing.authservice.component.token.ReturnToken;
+import com.phishing.authservice.payload.request.SignInRequest;
 import com.phishing.authservice.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -17,12 +18,12 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signin")
-    public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequest request) {
+    public ResponseEntity<ReturnToken> signIn(@RequestBody @Valid SignInRequest request) {
         return ResponseEntity.ok(authService.signIn(request));
     }
 
     @PostMapping("/signout")
-    public ResponseEntity<?> signOut(HttpServletRequest request){
+    public ResponseEntity<Void> signOut(HttpServletRequest request){
         authService.signOut(request);
         return ResponseEntity.ok().build();
     }

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/UserController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/UserController.java
@@ -51,4 +51,11 @@ public class UserController {
         userService.editProfile(httpServletRequest, editProfileRequest);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/resign")
+    public ResponseEntity<Void> resignUser(HttpServletRequest httpServletRequest) {
+        userService.resignUser(httpServletRequest);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/UserController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/UserController.java
@@ -1,8 +1,8 @@
 package com.phishing.authservice.controller;
 
-import com.phishing.authservice.dto.request.EditProfileRequest;
-import com.phishing.authservice.dto.request.SignUpRequest;
-import com.phishing.authservice.dto.request.VerifyEmailRequest;
+import com.phishing.authservice.payload.request.EditProfileRequest;
+import com.phishing.authservice.payload.request.SignUpRequest;
+import com.phishing.authservice.payload.request.VerifyEmailRequest;
 import com.phishing.authservice.service.MailService;
 import com.phishing.authservice.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,31 +22,31 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/users/check")
-    public ResponseEntity<?> checkEmail(@RequestParam @Valid @NotNull String email) {
+    public ResponseEntity<Void> checkEmail(@RequestParam @Valid @NotNull String email) {
         userService.checkEmail(email);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/email/send")
-    public ResponseEntity<?> sendMail(@RequestParam @Valid @NotNull String email) {
+    public ResponseEntity<Void> sendMail(@RequestParam @Valid @NotNull String email) {
         mailService.sendMail(email);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/email/verify")
-    public ResponseEntity<?> verifyMail(@RequestBody @Valid VerifyEmailRequest request) {
+    public ResponseEntity<Void> verifyMail(@RequestBody @Valid VerifyEmailRequest request) {
         mailService.verifyMail(request.email(), request.authCode());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<?> signUp(@RequestBody @Valid SignUpRequest request) {
+    public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
         userService.signUp(request);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/users/edit")
-    public ResponseEntity<?> editProfile(HttpServletRequest httpServletRequest
+    public ResponseEntity<Void> editProfile(HttpServletRequest httpServletRequest
             , @RequestBody @Valid EditProfileRequest editProfileRequest) {
         userService.editProfile(httpServletRequest, editProfileRequest);
         return ResponseEntity.ok().build();

--- a/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/domain/User.java
@@ -34,6 +34,9 @@ public class User {
     @Column(name = "role", nullable = false, length = 10)
     private UserRole role;
 
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -50,6 +53,7 @@ public class User {
                 .nickname(nickname)
                 .phnum(phnum)
                 .role(UserRole.USER)
+                .isDeleted(false)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -58,5 +62,10 @@ public class User {
         this.nickname = nickname;
         this.phnum = phnum;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void resignUser() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/exception/GlobalExceptionHandler.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.phishing.authservice.exception;
 
 import com.phishing.authservice.exception.exceptions.*;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,7 +9,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // todo: handle exception with custom message and status code, separated by exception type
     @ExceptionHandler( value = {
             DuplicateEmailException.class,
             InvalidPasswordException.class,
@@ -18,7 +16,7 @@ public class GlobalExceptionHandler {
             AuthCodeExpireException.class,
             InvalidAuthCodeException.class
     })
-    protected ResponseEntity<?> handleException(Exception e) {
+    protected ResponseEntity<String> handleException(Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/exception/exceptions/FailCreateKeyException.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/exception/exceptions/FailCreateKeyException.java
@@ -1,0 +1,7 @@
+package com.phishing.authservice.exception.exceptions;
+
+public class FailCreateKeyException extends RuntimeException{
+    public FailCreateKeyException(String message) {
+        super(message);
+    }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/payload/request/EditProfileRequest.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/payload/request/EditProfileRequest.java
@@ -1,4 +1,4 @@
-package com.phishing.authservice.dto.request;
+package com.phishing.authservice.payload.request;
 
 public record EditProfileRequest(
         String nickname,

--- a/src/auth-service/src/main/java/com/phishing/authservice/payload/request/SignInRequest.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/payload/request/SignInRequest.java
@@ -1,4 +1,4 @@
-package com.phishing.authservice.dto.request;
+package com.phishing.authservice.payload.request;
 
 public record SignInRequest(
     String email,

--- a/src/auth-service/src/main/java/com/phishing/authservice/payload/request/SignUpRequest.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/payload/request/SignUpRequest.java
@@ -1,4 +1,4 @@
-package com.phishing.authservice.dto.request;
+package com.phishing.authservice.payload.request;
 
 public record SignUpRequest(
         String email,

--- a/src/auth-service/src/main/java/com/phishing/authservice/payload/request/VerifyEmailRequest.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/payload/request/VerifyEmailRequest.java
@@ -1,4 +1,4 @@
-package com.phishing.authservice.dto.request;
+package com.phishing.authservice.payload.request;
 
 public record VerifyEmailRequest(
         String email,

--- a/src/auth-service/src/main/java/com/phishing/authservice/payload/token/MemberInfo.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/payload/token/MemberInfo.java
@@ -1,4 +1,4 @@
-package com.phishing.authservice.payload;
+package com.phishing.authservice.payload.token;
 
 import com.phishing.authservice.domain.UserRole;
 import lombok.Builder;

--- a/src/auth-service/src/main/java/com/phishing/authservice/repository/UserRepository.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/repository/UserRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
-    Optional<User> findByEmail(String email);
+    Optional<User> findByEmailAndIsDeletedIsFalse(String email);
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
         // Check if email isn't exists
         userRepository.existsByEmail(request.email());
         // Check if password is correct
-        User loginUser = userRepository.findByEmail(request.email())
+        User loginUser = userRepository.findByEmailAndIsDeletedIsFalse(request.email())
                 .filter(user -> passwordEncoder.matches(request.password(), user.getPassword()))
                 .orElseThrow(() -> new InvalidPasswordException("Invalid password"));
         // return jwt token

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
@@ -4,10 +4,7 @@ import com.phishing.authservice.component.token.ReturnToken;
 import com.phishing.authservice.component.token.TokenProvider;
 import com.phishing.authservice.component.token.TokenResolver;
 import com.phishing.authservice.domain.User;
-import com.phishing.authservice.domain.UserRole;
-import com.phishing.authservice.dto.request.SignInRequest;
-import com.phishing.authservice.dto.request.SignUpRequest;
-import com.phishing.authservice.exception.exceptions.DuplicateEmailException;
+import com.phishing.authservice.payload.request.SignInRequest;
 import com.phishing.authservice.exception.exceptions.InvalidPasswordException;
 import com.phishing.authservice.redis.RedisDao;
 import com.phishing.authservice.repository.UserRepository;
@@ -57,8 +54,8 @@ public class AuthService {
         String accessToken = request.getHeader("Authorization");
         String refreshToken = request.getHeader("RefreshToken");
         // set refresh token's blacklist ttl
-        long refreshTime = tokenResolver.getExpiration(refreshToken);
-        long ttl = refreshTime - System.currentTimeMillis();
+        long remainTime = tokenResolver.getExpiration(refreshToken);
+        long ttl = remainTime - System.currentTimeMillis();
         // Get user email from jwt token
         String email = tokenResolver.getClaims(accessToken).email();
         // Delete refresh token in redis

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/MailService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/MailService.java
@@ -1,6 +1,7 @@
 package com.phishing.authservice.service;
 
 import com.phishing.authservice.exception.exceptions.AuthCodeExpireException;
+import com.phishing.authservice.exception.exceptions.FailCreateKeyException;
 import com.phishing.authservice.exception.exceptions.InvalidAuthCodeException;
 import com.phishing.authservice.exception.exceptions.FailSendEmailException;
 import com.phishing.authservice.redis.RedisDao;
@@ -79,7 +80,9 @@ public class MailService {
             return key.toString();
         } catch (NoSuchAlgorithmException e) {
             log.error("Failed to create random key", e);
-            throw new RuntimeException("Failed to create random key");
+            throw new FailCreateKeyException("Failed to create random key");
         }
     }
+
+
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/UserService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/UserService.java
@@ -5,7 +5,7 @@ import com.phishing.authservice.domain.User;
 import com.phishing.authservice.payload.request.EditProfileRequest;
 import com.phishing.authservice.payload.request.SignUpRequest;
 import com.phishing.authservice.exception.exceptions.DuplicateEmailException;
-import com.phishing.authservice.payload.MemberInfo;
+import com.phishing.authservice.payload.token.MemberInfo;
 import com.phishing.authservice.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -47,13 +47,20 @@ public class UserService {
     public void editProfile(HttpServletRequest httpServletRequest, EditProfileRequest request){
         MemberInfo memberInfo = getMemberInfoToToken(httpServletRequest);
 
-        User targetUser = userRepository.findByEmail(memberInfo.email())
+        User targetUser = userRepository.findByEmailAndIsDeletedIsFalse(memberInfo.email())
                 .orElseThrow(() -> new DuplicateEmailException("Email Not exists"));
 
         targetUser.editProfile(
                 request.nickname(),
                 request.phnum()
         );
+    }
+
+    public void resignUser(HttpServletRequest request) {
+        MemberInfo memberInfo = getMemberInfoToToken(request);
+        User targetUser = userRepository.findByEmailAndIsDeletedIsFalse(memberInfo.email())
+                .orElseThrow(() -> new DuplicateEmailException("Email Not exists"));
+        targetUser.resignUser();
     }
 
     private MemberInfo getMemberInfoToToken(HttpServletRequest request) {

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/UserService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/UserService.java
@@ -2,8 +2,8 @@ package com.phishing.authservice.service;
 
 import com.phishing.authservice.component.token.TokenResolver;
 import com.phishing.authservice.domain.User;
-import com.phishing.authservice.dto.request.EditProfileRequest;
-import com.phishing.authservice.dto.request.SignUpRequest;
+import com.phishing.authservice.payload.request.EditProfileRequest;
+import com.phishing.authservice.payload.request.SignUpRequest;
 import com.phishing.authservice.exception.exceptions.DuplicateEmailException;
 import com.phishing.authservice.payload.MemberInfo;
 import com.phishing.authservice.repository.UserRepository;
@@ -54,12 +54,10 @@ public class UserService {
                 request.nickname(),
                 request.phnum()
         );
-        System.out.println("targetUser = " + targetUser.getNickname());
     }
 
     private MemberInfo getMemberInfoToToken(HttpServletRequest request) {
         String token = request.getHeader("Authorization");
-        MemberInfo result = tokenResolver.getClaims(token);
-        return result;
+        return tokenResolver.getClaims(token);
     }
 }

--- a/src/auth-service/src/main/resources/application.yml
+++ b/src/auth-service/src/main/resources/application.yml
@@ -17,3 +17,5 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: create-drop
+server:
+  port: 8082


### PR DESCRIPTION
### Issue Number or Link
#24  

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
Auth 서비스 회원 탈퇴 구현 및 기타 로직 리팩토링

### 상세 내용(Describe your changes)
**Auth 서비스의 회원 탈퇴 기능을 구현하였습니다.**
- 회원탈퇴를 위해 soft delete를 반영 할 컬럼을 추가하였습니다.
- 회원 탈퇴 시 soft delete가 실행되고, 삭제 된 시간이 저장됩니다.

**기타 로직들을 리팩토링 하였습니다.**
- 토큰에 들어가는 정보에 토큰 생성 일시를 추가하였습니다.
- soft delete 반영에 따른 레포지토리 메소드 등 변경사항을 반영하였습니다.

### 참고 사항
- soft delete 된 유저의 정보를 추후 배치 작업을 통해 hard delete를 하는 로직을 수행해야 합니다.


