### PR TITLE
refactor: Auth 서비스 gateway 연결을 위한 refactoring

### DIFF
--- a/src/auth-service/build.gradle
+++ b/src/auth-service/build.gradle
@@ -21,6 +21,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2023.0.0")
+}
+
 dependencies {
 	// Spring Boot MVC
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -54,6 +58,16 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+	// Spring Cloud Eureka
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/passport/Passport.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/passport/Passport.java
@@ -1,6 +1,7 @@
 package com.phishing.authservice.component.passport;
 
 public record Passport (
+    Long userId,
     String email,
     String nickname,
     String role

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/passport/Passport.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/passport/Passport.java
@@ -1,0 +1,8 @@
+package com.phishing.authservice.component.passport;
+
+public record Passport (
+    String email,
+    String nickname,
+    String role
+){
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/passport/PassportGenerator.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/passport/PassportGenerator.java
@@ -1,0 +1,15 @@
+package com.phishing.authservice.component.passport;
+
+import com.phishing.authservice.domain.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PassportGenerator {
+        public Passport generatePassport(User user){
+            return new Passport(
+                    user.getEmail(),
+                    user.getNickname(),
+                    user.getRole().toString()
+            );
+        }
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/passport/PassportGenerator.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/passport/PassportGenerator.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 public class PassportGenerator {
         public Passport generatePassport(User user){
             return new Passport(
+                    user.getId(),
                     user.getEmail(),
                     user.getNickname(),
                     user.getRole().toString()

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
@@ -23,7 +23,7 @@ public class TokenProvider {
 
     public ReturnToken provideTokens(User user) {
         Claims claims = buildClaims(user);
-        Claims refresh_claims = buildClaims(user.getEmail());
+        Claims refresh_claims = buildClaims(user.getId());
         return new ReturnToken(
                 generateToken(claims, ACCESS_TIME),
                 generateToken(refresh_claims, REFRESH_TIME)
@@ -40,15 +40,13 @@ public class TokenProvider {
 
     private static Claims buildClaims(User user) {
         Claims claims = Jwts.claims();
-        claims.put("USER_ID", user.getEmail());
-        claims.put("USER_NICKNAME", user.getNickname());
-        claims.put("USER_ROLE", user.getRole());
+        claims.put("USER_ID", user.getId());
         return claims;
     }
 
-    private static Claims buildClaims(String email) {
+    private static Claims buildClaims(Long id) {
         Claims claims = Jwts.claims();
-        claims.put("USER_ID", email);
+        claims.put("USER_ID", id);
         return claims;
     }
 

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenProvider.java
@@ -22,8 +22,8 @@ public class TokenProvider {
     private String SECRET_KEY;
 
     public ReturnToken provideTokens(User user) {
-        Claims claims = buildClaims(user);
-        Claims refresh_claims = buildClaims(user.getId());
+        Claims claims = buildAccessClaims(user.getId());
+        Claims refresh_claims = buildRefreshClaims(user.getId());
         return new ReturnToken(
                 generateToken(claims, ACCESS_TIME),
                 generateToken(refresh_claims, REFRESH_TIME)
@@ -38,14 +38,16 @@ public class TokenProvider {
                 .compact();
     }
 
-    private static Claims buildClaims(User user) {
+    private static Claims buildAccessClaims(Long id) {
         Claims claims = Jwts.claims();
-        claims.put("USER_ID", user.getId());
+        claims.put("TOKEN_TYPE", "ACCESS");
+        claims.put("USER_ID", id);
         return claims;
     }
 
-    private static Claims buildClaims(Long id) {
+    private static Claims buildRefreshClaims(Long id) {
         Claims claims = Jwts.claims();
+        claims.put("TOKEN_TYPE", "REFRESH");
         claims.put("USER_ID", id);
         return claims;
     }

--- a/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenResolver.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/component/token/TokenResolver.java
@@ -15,30 +15,24 @@ public class TokenResolver {
     @Value("${jwt.secret.key}")
     private String SECRET_KEY;
 
-    public MemberInfo getAccessClaims(String token){
+    public Long getAccessClaims(String token){
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(SECRET_KEY)
                 .build()
                 .parseClaimsJws(removePrefix(token))
                 .getBody();
 
-        return MemberInfo.builder()
-                .email(claims.get("USER_ID", String.class))
-                .nickname(claims.get("USER_NICKNAME", String.class))
-                .role(UserRole.valueOf(claims.get("USER_ROLE", String.class)))
-                .build();
+        return claims.get("USER_ID", Long.class);
     }
 
-    public MemberInfo getRefreshClaims(String token){
+    public Long getRefreshClaims(String token){
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(SECRET_KEY)
                 .build()
                 .parseClaimsJws(removePrefix(token))
                 .getBody();
 
-        return MemberInfo.builder()
-                .email(claims.get("USER_ID", String.class))
-                .build();
+        return claims.get("USER_ID", Long.class);
     }
 
     public long getExpiration(String token){

--- a/src/auth-service/src/main/java/com/phishing/authservice/config/DiscoveryConfig.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/config/DiscoveryConfig.java
@@ -1,0 +1,9 @@
+package com.phishing.authservice.config;
+
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableDiscoveryClient
+public class DiscoveryConfig {
+}

--- a/src/auth-service/src/main/java/com/phishing/authservice/config/SecurityConfig.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/config/SecurityConfig.java
@@ -20,12 +20,12 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable)
                 .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/v1/**").permitAll()
+                        .requestMatchers("/auth/api/v1/**").permitAll()
                         .requestMatchers("/v3/**", "/swagger-ui/**").permitAll()
-                        .requestMatchers("/api/v1/signout").authenticated()
-                )
-                .build();
+                        .anyRequest().permitAll()
+                ).build();
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.phishing.authservice.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.phishing.authservice.component.token.ReturnToken;
 import com.phishing.authservice.payload.request.SignInRequest;
 import com.phishing.authservice.service.AuthService;
@@ -11,7 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/auth/api/v1")
 @RequiredArgsConstructor
 @Validated
 public class AuthController {
@@ -31,5 +32,10 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<ReturnToken> refresh(HttpServletRequest request){
         return ResponseEntity.ok(authService.refresh(request));
+    }
+
+    @PostMapping("/passport")
+    public ResponseEntity<String> generatePassport(HttpServletRequest request) throws JsonProcessingException {
+        return ResponseEntity.ok(authService.generatePassport(request));
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/controller/UserController.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/controller/UserController.java
@@ -1,5 +1,9 @@
 package com.phishing.authservice.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phishing.authservice.component.passport.Passport;
+import com.phishing.authservice.domain.User;
 import com.phishing.authservice.payload.request.EditProfileRequest;
 import com.phishing.authservice.payload.request.SignUpRequest;
 import com.phishing.authservice.payload.request.VerifyEmailRequest;
@@ -14,12 +18,13 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/auth/api/v1")
 @RequiredArgsConstructor
 @Validated
 public class UserController {
     private final MailService mailService;
     private final UserService userService;
+    private final ObjectMapper objectMapper;
 
     @GetMapping("/users/check")
     public ResponseEntity<Void> checkEmail(@RequestParam @Valid @NotNull String email) {
@@ -46,15 +51,18 @@ public class UserController {
     }
 
     @PostMapping("/users/edit")
-    public ResponseEntity<Void> editProfile(HttpServletRequest httpServletRequest
-            , @RequestBody @Valid EditProfileRequest editProfileRequest) {
-        userService.editProfile(httpServletRequest, editProfileRequest);
+    public ResponseEntity<Void> editProfile(@RequestHeader("X-Authorization") String passport
+            , @RequestBody @Valid EditProfileRequest editProfileRequest) throws JsonProcessingException {
+        Passport userInfo = objectMapper.readValue(passport, Passport.class);
+        userService.editProfile(userInfo, editProfileRequest);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/resign")
-    public ResponseEntity<Void> resignUser(HttpServletRequest httpServletRequest) {
-        userService.resignUser(httpServletRequest);
+    public ResponseEntity<Void> resignUser(
+            @RequestHeader("X-Authorization") String passport) throws JsonProcessingException {
+        Passport userInfo = objectMapper.readValue(passport, Passport.class);
+        userService.resignUser(userInfo);
         return ResponseEntity.ok().build();
     }
 

--- a/src/auth-service/src/main/java/com/phishing/authservice/repository/UserRepository.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/repository/UserRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
+    Optional<User> findByIdAndIsDeletedIsFalse(Long id);
     Optional<User> findByEmailAndIsDeletedIsFalse(String email);
+
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/AuthService.java
@@ -1,11 +1,16 @@
 package com.phishing.authservice.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phishing.authservice.component.passport.Passport;
+import com.phishing.authservice.component.passport.PassportGenerator;
 import com.phishing.authservice.component.token.ReturnToken;
 import com.phishing.authservice.component.token.TokenProvider;
 import com.phishing.authservice.component.token.TokenResolver;
 import com.phishing.authservice.domain.User;
 import com.phishing.authservice.payload.request.SignInRequest;
 import com.phishing.authservice.exception.exceptions.InvalidPasswordException;
+import com.phishing.authservice.payload.token.MemberInfo;
 import com.phishing.authservice.redis.RedisDao;
 import com.phishing.authservice.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,9 +34,14 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
     private final TokenResolver tokenResolver;
+    private final PassportGenerator passportGenerator;
+    private final ObjectMapper objectMapper;
 
     @Value("${jwt.secret.refresh}")
     private Long refreshTime;
+
+    private static final String ACCESS_TOKEN_HEADER = "Authorization";
+    private static final String REFRESH_TOKEN_HEADER = "RefreshToken";
 
     public ReturnToken signIn(SignInRequest request) {
         userRepository.existsByEmail(request.email());
@@ -46,8 +56,8 @@ public class AuthService {
     }
 
     public void signOut(HttpServletRequest request) {
-        String accessToken = request.getHeader("Authorization");
-        String refreshToken = request.getHeader("RefreshToken");
+        String accessToken = request.getHeader(ACCESS_TOKEN_HEADER);
+        String refreshToken = request.getHeader(REFRESH_TOKEN_HEADER);
         long remainTime = tokenResolver.getExpiration(refreshToken);
         long ttl = remainTime - System.currentTimeMillis();
         String email = tokenResolver.getAccessClaims(accessToken).email();
@@ -58,7 +68,7 @@ public class AuthService {
     }
 
     public ReturnToken refresh(HttpServletRequest request) {
-        String refreshToken = request.getHeader("RefreshToken");
+        String refreshToken = request.getHeader(REFRESH_TOKEN_HEADER);
         String email = tokenResolver.getRefreshClaims(refreshToken).email();
         if (!redisDao.isExistKey(email) || !redisDao.getRedisValues(email).equals(refreshToken)) {
             throw new InvalidPasswordException("Invalid refresh token");
@@ -70,5 +80,16 @@ public class AuthService {
                 returnToken.refreshToken(), Duration.ofMillis(refreshTime));
 
         return returnToken;
+    }
+
+    public String generatePassport(HttpServletRequest request) throws JsonProcessingException {
+        String accessToken = request.getHeader(ACCESS_TOKEN_HEADER);
+        String user_email = tokenResolver.getAccessClaims(accessToken).email();
+        User user = userRepository.findByEmailAndIsDeletedIsFalse(user_email)
+                .orElseThrow(() -> new InvalidPasswordException("Invalid access token"));
+        Passport result = passportGenerator.generatePassport(user);
+        log.debug("Passport: {}", result);
+        String passport = objectMapper.writeValueAsString(result);
+        return passport;
     }
 }

--- a/src/auth-service/src/main/java/com/phishing/authservice/service/UserService.java
+++ b/src/auth-service/src/main/java/com/phishing/authservice/service/UserService.java
@@ -1,5 +1,6 @@
 package com.phishing.authservice.service;
 
+import com.phishing.authservice.component.passport.Passport;
 import com.phishing.authservice.component.token.TokenResolver;
 import com.phishing.authservice.domain.User;
 import com.phishing.authservice.payload.request.EditProfileRequest;
@@ -40,10 +41,8 @@ public class UserService {
         userRepository.save(user);
     }
 
-    public void editProfile(HttpServletRequest httpServletRequest, EditProfileRequest request){
-        MemberInfo memberInfo = getMemberInfoToToken(httpServletRequest);
-
-        User targetUser = userRepository.findByEmailAndIsDeletedIsFalse(memberInfo.email())
+    public void editProfile(Passport passport, EditProfileRequest request){
+        User targetUser = userRepository.findByIdAndIsDeletedIsFalse(passport.userId())
                 .orElseThrow(() -> new DuplicateEmailException("Email Not exists"));
 
         targetUser.editProfile(
@@ -52,14 +51,14 @@ public class UserService {
         );
     }
 
-    public void resignUser(HttpServletRequest request) {
-        MemberInfo memberInfo = getMemberInfoToToken(request);
-        User targetUser = userRepository.findByEmailAndIsDeletedIsFalse(memberInfo.email())
+    public void resignUser(Passport passport) {
+        Long userId = passport.userId();
+        User targetUser = userRepository.findByIdAndIsDeletedIsFalse(userId)
                 .orElseThrow(() -> new DuplicateEmailException("Email Not exists"));
         targetUser.resignUser();
     }
 
-    private MemberInfo getMemberInfoToToken(HttpServletRequest request) {
+    private Long getMemberInfoToToken(HttpServletRequest request) {
         String token = request.getHeader("Authorization");
         return tokenResolver.getAccessClaims(token);
     }

--- a/src/auth-service/src/main/resources/application.yml
+++ b/src/auth-service/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: auth-service
   profiles:
     active: jwt, mail
   data:
@@ -17,5 +19,16 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: create-drop
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
 server:
   port: 8082
+logging:
+  level:
+    org:
+      springframework:
+        security: DEBUG


### PR DESCRIPTION
### Issue Number or Link
#31 

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
Auth 서비스 토큰 재발급 구현

### 상세 내용(Describe your changes)
**Gateway 적용에 따른 일부 로직들을 리팩토링 하였습니다.**
- 토큰에 들어가는 정보들을 수정하였습니다.
    - 토큰에는 토큰 타입과, userId 외에는 어떠한 정보도 들어가있지 않습니다.
    - 토큰을 통해 Auth 서비스에서 Passport를 발급합니다.
**유저의 정보를 필요한 경우 헤더에서 유저의 정보를 불러옵니다.**
- 발급된 Passport는 마이크로서비스 네트워크 내에서 헤더에 탑재되어 통신됩니다.
- X-Authorization 헤더에 유저 정보가 포함됩니다.


### 참고 사항


